### PR TITLE
SWI-7509: vault-shim should forward child process exit signal

### DIFF
--- a/cmd/runCmd.go
+++ b/cmd/runCmd.go
@@ -53,8 +53,9 @@ var (
 			app.Dir = workingDir
 			app.Args = args[1:]
 			app.Env = env
-			if _, err := app.Run(); err != nil {
-				logrus.Fatal(err)
+			if processState, err := app.Run(); err != nil {
+				logrus.Error(err)
+				os.Exit(processState.ExitCode())
 			}
 			return nil
 		},


### PR DESCRIPTION
testing
```
ddefisher@ddefisher-mbp ~/workspace/vault-shim (main) $ ./vault-shim run-cmd -v  -- ./test.sh

^CERRO[0005] ./test.sh exited with non-zero exit code: exit status 156
ddefisher@ddefisher-mbp ~/workspace/vault-shim (main) $ echo $?
156